### PR TITLE
Add Docker Hub authentication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,10 @@ executors:
     snippets:
         docker:
             - image: cnerg/snippets
-            
+              auth:
+                username: cnerg
+                password: $DOCKERHUB_PASSWORD
+
 jobs:
     # CI initializing job.
     init:
@@ -20,7 +23,7 @@ jobs:
     #         name: snippets
     #     steps:
     #         - checkout
-    #         - run: 
+    #         - run:
     #               name: Test script X.
     #               command: |
     #                   echo "This is a template job."
@@ -28,8 +31,10 @@ jobs:
 workflows:
     test:
         jobs:
-            - init
+            - init:
+                context: dockerhub-cnerg
     ### Template. ###
-    #         - test_script_x
+    #         - test_script_x:
+    #             context: dockerhub-cnerg
     #             requires:
     #                 - init

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@ executors:
         docker:
             - image: cnerg/snippets
               auth:
-                username: cnerg
-                password: $DOCKERHUB_PASSWORD
+                username: $DOCKERHUB_USER
+                password: $DOCKERHUB_PASS
 
 jobs:
     # CI initializing job.
@@ -32,9 +32,9 @@ workflows:
     test:
         jobs:
             - init:
-                context: dockerhub-cnerg
+                context: dockerhub
     ### Template. ###
     #         - test_script_x:
-    #             context: dockerhub-cnerg
+    #             context: dockerhub
     #             requires:
     #                 - init


### PR DESCRIPTION
This PR adds Docker Hub authentication for CI according to upcoming changes on Docker Hub policy.
On Docker Hub, a context named `dockerhub` should be created. Until then, the CI test will fail.